### PR TITLE
Support github actions/workflows ...

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,9 +157,7 @@
     "yarn-deduplicate": "^3.1.0"
   },
   "dependencies": {
-    "@octokit/plugin-retry": "^3.0.7",
-    "@octokit/plugin-throttling": "^3.4.1",
-    "@octokit/rest": "^18.0.15",
+    "@octokit/graphql": "^4.6.1",
     "date-fns": "^2.16.1",
     "electron-debug": "^3.1.0",
     "electron-log": "^4.2.4",

--- a/src/Fetcher.jsx
+++ b/src/Fetcher.jsx
@@ -6,46 +6,17 @@ import dateMin from 'date-fns/min'
 import dateMax from 'date-fns/max'
 import formatDistance from 'date-fns/formatDistance'
 
-import {Octokit} from '@octokit/rest'
-import {retry} from "@octokit/plugin-retry"
-import {throttling} from "@octokit/plugin-throttling"
+import {graphql} from '@octokit/graphql'
 
 export const Fetcher = (props) => {
   const [interval, _] = useStore('interval')
   const [repoIds, setRepoIds] = useStore('repo_ids')
 
-  const octokit = new Octokit({
-    auth: `token ${store.get('github_token')}`,
-    throttle: {
-      onRateLimit: (retryAfter, options) => {
-        myOctokit.log.warn(
-          `Request quota exhausted for request ${options.method} ${options.url}`
-        );
-
-        if (options.request.retryCount === 0) {
-          // only retries once
-          myOctokit.log.info(`Retrying after ${retryAfter} seconds!`);
-          return true;
-        }
-      },
-      onAbuseLimit: (retryAfter, options) => {
-        // does not retry, only logs a warning
-        myOctokit.log.warn(
-          `Abuse detected for request ${options.method} ${options.url}`
-        );
-      },
-    },
-    retry: {
-      doNotRetry: ["429"],
-    },
-    log: {
-      debug: () => { },
-      info: () => { },
-      warn: console.warn,
-      error: console.error
+  const graphqlWithAuth = graphql.defaults({
+    headers: {
+      authorization: `token ${store.get('github_token')}`,
     },
   })
-
 
   useEffect(() => {
     store.onDidAnyChange(fetchData)
@@ -57,18 +28,79 @@ export const Fetcher = (props) => {
   const fetchData = async () => {
     setLoading(true)
     const newDetails = await Promise.all(repoIds.map(async (repoId) => {
-
       try {
         const [owner, repo] = repoId.split('/')
-        const repoDetails = await octokit.repos.get({owner, repo})
-        const ref = repoDetails.data.default_branch
 
-        console.log(await octokit.repos.getCommit({owner,repo,ref}))
+        const { repository } = await graphqlWithAuth(
+          `query {
+            repository(owner: "${owner}", name: "${repo}") {
+              url
+              defaultBranchRef {
+                target {
+                  ... on Commit {
+                    url
+                    status {
+                      contexts {
+                        id
+                        avatarUrl
+                        context
+                        createdAt
+                        state
+                        targetUrl
+                      }
+                    }
+                    statusCheckRollup {
+                      state
+                      contexts(first: 20) {
+                        edges {
+                          node {
+                            ... on CheckRun {
+                              id
+                              name
+                              completedAt
+                              conclusion
+                              url
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }`
+        )
 
+        const commit = repository.defaultBranchRef?.target
+        
+        // break if there is no commit or the commit has no status
+        if (!commit?.statusCheckRollup) return { repoId, statuses: [] }
 
-        const commitStatus = (await octokit.repos.getCombinedStatusForRef({owner, repo, ref})).data
-        const createdAt = dateMax((commitStatus.statuses || []).map(v => new Date(v.created_at)))
-        return { repoId, createdAt, ...commitStatus }
+        const statuses = [
+          // status checks such as github workflows/actions, linter integrations etc.
+          // currently includes classic commit statuses as empty nodes - hopefully
+          // it will contain all data at some point.
+          ...commit.statusCheckRollup.contexts.edges.map(e => e.node).filter(e => e.id),
+          // classic commit status flags. fetching these too might become obsolete.
+          // let's unify their data model with that of checks until then.
+          ...(commit.status?.contexts || []).map(e => ({
+            avatarUrl:   e.avatarUrl,
+            completedAt: e.createdAt,
+            conclusion:  e.state,
+            id:          e.id,
+            name:        e.context,
+            url:         e.targetUrl,
+          })),
+        ]
+        statuses.forEach(s => s.conclusion = simplifiedState(s.conclusion))
+
+        const createdAt = dateMax(statuses.map(v => new Date(v.completedAt)))
+        
+        // github helpfully provides a combined state that covers checks AND status.
+        const state = simplifiedState(commit.statusCheckRollup.state)
+
+        return { commitUrl: commit.url, repoId, createdAt, state, statuses }
       }
       catch (err) {
         return { repoId, errorName: err.name, errorMessage: err.message }
@@ -88,3 +120,20 @@ export const Fetcher = (props) => {
 }
 
 const LoadingIcon = () => <svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="download" class="w-4" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M216 0h80c13.3 0 24 10.7 24 24v168h87.7c17.8 0 26.7 21.5 14.1 34.1L269.7 378.3c-7.5 7.5-19.8 7.5-27.3 0L90.1 226.1c-12.6-12.6-3.7-34.1 14.1-34.1H192V24c0-13.3 10.7-24 24-24zm296 376v112c0 13.3-10.7 24-24 24H24c-13.3 0-24-10.7-24-24V376c0-13.3 10.7-24 24-24h146.7l49 49c20.1 20.1 52.5 20.1 72.6 0l49-49H488c13.3 0 24 10.7 24 24zm-124 88c0-11-9-20-20-20s-20 9-20 20 9 20 20 20 20-9 20-20zm64 0c0-11-9-20-20-20s-20 9-20 20 9 20 20 20 20-9 20-20z"></path></svg>
+
+// map various github StatusState / CheckConclusionState values to a smaller set
+const simplifiedState = (githubState) =>
+({
+  ACTION_REQUIRED:    'failure',
+  CANCELLED:          'failure',
+  ERROR:              'failure',
+  EXPECTED:           'success',
+  FAILURE:            'failure',
+  NEUTRAL:            'pending',
+  PENDING:            'pending',
+  SKIPPED:            'pending',
+  STALE:              'failure',
+  STARTUP_FAILURE:    'failure',
+  SUCCESS:            'success',
+  TIMED_OUT:          'failure',
+}[String(githubState).toUpperCase()])

--- a/src/RepoDetails.jsx
+++ b/src/RepoDetails.jsx
@@ -5,8 +5,8 @@ const githubLogo = ' data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAA
 
 export const RepoDetails = (props) => {
   return <div className='h-screen relative'>
-    {(props.statuses || []).map(status => <Item {...status} key={status.context} />)}
-    {props.repository?.html_url && <Item avatar_url={githubLogo} target_url={`${props.repository.html_url}/commit/${props.sha}`} context='open commit' />}
+    {(props.statuses || []).map(status => <Item {...status} key={status.id} showConclusion />)}
+    {props.commitUrl && <Item url={props.commitUrl} name='open commit' />}
     <Bug
       className='w-8 absolute bottom-0 right-0 text-gray-200 hover:text-gray-300 cursor-pointer p-2'
       onClick={() => console.log(props)}
@@ -15,10 +15,11 @@ export const RepoDetails = (props) => {
 }
 
 const Item = (props) => {
-  return <div className="flex justify-between items-center hover:bg-gray-100 cursor-pointer p-2 border-b" onClick={() => shell.openExternal(props.target_url)}>
-    <img className='flex-shrink-0 flex-grow-0 mr-2' src={props.avatar_url} width="24" height="24" />
+  return <div className="flex justify-between items-center hover:bg-gray-100 cursor-pointer p-2 border-b" onClick={() => shell.openExternal(props.url)}>
+    {props.showConclusion && <img className='flex-shrink-0 flex-grow-0 mr-2' src={conclusionIcon(props.conclusion)} width="24" height="24" />}
+    <img className='flex-shrink-0 flex-grow-0 mr-2' src={props.avatarUrl || githubLogo} width="24" height="24" />
     <div className='text-sm flex-grow flex-shrink'>
-      {props.context}
+      {props.name}
     </div>
     <img width="12" height="12" className='flex-shrink-0 flex-grow-0' src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADMAAABQCAYAAAC0wU3eAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAOxAAADsQBlSsOGwAABOlJREFUeJztmj1sG2Ucxp//2VHJBxmQkNpKYUFiYEaIhY8sIAYWJAx357RpB6TaLgMLNE1i56tphRgQdiRLBZHEd5bcARHEiAoTCAlYqRADVSNFYkciudzTIXaxyp19H+/ruCjPFvvuef6/vP973/fOB/yPJHFPKN++nT19794zMIyJw5GRu6Vcbk9HYUkUGaZer48cjD8+B/A9EXmi8zmBHwm+f9m2f9BTYnRFgvm41Rp9bN/7EoLXAg8gPRFYBdu+pbS6mDL6HVCv74ydOvB2QkEAQCTrE80Nx3lLaXUx1XNkPtraGh/NZL8WYDqKGclDGGKVLKulprx4CoWptloTcuB9A+ClOIbHCRTYZiQF+56LmCAAICIZ+HSrrptLXV1MBcLUXPd1EbyR1LQDVGs0305eWnwFTwCU1EWISIbwnUECBcKI4GkV5oMGCr5mgH1VASKSgQym5ULWGf6sPGcAQIEwhu/fJHmoPEvofuo47yj27QoIUGFm5g4E8zryDIijCyh0O1O0rBsEbujINCBO1XVN1cY9tzMkpeY21wX4QHUwAJ+CfMmymqoMe240RYRFy7wC4rqqwO5sIRoqR6jvrllEWLDNOZ1AG42mpcIs8s0ZSdlwmtcg+FBF8EPyhTJTyJtuGpO+I9NRZ4QIrqcJDKuDwu2q49hpTGI/AziaFNw1gVxJExwin+C5km07SU6ODQPoB4LgfNGyGnFPTAQDPLiGViGYS+rRQ4mAEsMAwwcUeQIIUntSmCexlsYnRAaIzZrr5qOfkFIiwqJtLugCos+tqECp2qxbJKXmNFdEcFWVZ5c3AeN8KW9u9zpOGUw7VDZcdxkQ5TvuKEBKYdqhxwaU+pp5WCLCgmUtAlzV4C2Av1lznHNB3yuHaYceARErGryFxBdBQMrbrFvtdWgJggUN3v9pOa0w7VCpOc2KCBY1mHtiyPMFy/oV0NRm3WqvQxUSyxrMs77/7z9JO8xRpk4gvloulw1gQDDAEVApb5UJ7ij1hYxNTU2NAwOEAYDqtnsRTP5APlDkP5OTk38DA4SpbrsXIbx5tFaoEwXf53K5Q2BAMLpAAIC+8eA2XjuMVhBi+fKM+V3nb63rjE4QENcLtjknIux8pA1m0CCApjbT2lrgehAIoGFkdIMULetqEAigGEZza10r2OZ8GAigEOa4QQAgoyKr5jgXAHymafpdK9rmQj8QQMHI1BznAnn8IEBKmGECAVLA6AQBuFqwrMU4IEBCmGEEARLAVBuNWUA+1zRrrRRss5wEBIgJM8wgQAyYYQcBIu7NdIKQWFYBAkQYGd0gRdusqAAB+sBobS1wqWjbFZWO4e9ouq4Jn86jAgKEwNQ3W095mYPfIDKqOlAXCBAyARxkvHcfNRAg9LVGvqA+Si8IEP7C6ZjKEBIV3SBA2DuawruqAkhUSnlrSZVfLwWPjMhXauxZHhQIEALz15kzt0j8lM6a5aJtq3/q30OBMEvT017Gy74J8o9ktoMHAXrszS7N5nYNb+RlEr/HMSS4eBwgQJ+N5qXZ3C4NvELgThQzgosl21b+o2xURdqqVFut0zjwvhXg2bBjSCyU8pbyn8vjKNItQCmX2zs1kn2RxBYAv/s7grs+aB43CJDgtvmTVuvJkf3D5yD+hAB/7p09+8vS9LSno7gTnehEJzrRiYZJ9wE+7lpS3DuPnwAAAABJRU5ErkJggg==" />
   </div>
@@ -26,4 +27,14 @@ const Item = (props) => {
 
 const Bug = (props) => {
   return <svg {...props} aria-hidden="true" focusable="false" data-prefix="fas" data-icon="bug" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M511.988 288.9c-.478 17.43-15.217 31.1-32.653 31.1H424v16c0 21.864-4.882 42.584-13.6 61.145l60.228 60.228c12.496 12.497 12.496 32.758 0 45.255-12.498 12.497-32.759 12.496-45.256 0l-54.736-54.736C345.886 467.965 314.351 480 280 480V236c0-6.627-5.373-12-12-12h-24c-6.627 0-12 5.373-12 12v244c-34.351 0-65.886-12.035-90.636-32.108l-54.736 54.736c-12.498 12.497-32.759 12.496-45.256 0-12.496-12.497-12.496-32.758 0-45.255l60.228-60.228C92.882 378.584 88 357.864 88 336v-16H32.666C15.23 320 .491 306.33.013 288.9-.484 270.816 14.028 256 32 256h56v-58.745l-46.628-46.628c-12.496-12.497-12.496-32.758 0-45.255 12.498-12.497 32.758-12.497 45.256 0L141.255 160h229.489l54.627-54.627c12.498-12.497 32.758-12.497 45.256 0 12.496 12.497 12.496 32.758 0 45.255L424 197.255V256h56c17.972 0 32.484 14.816 31.988 32.9zM257 0c-61.856 0-112 50.144-112 112h224C369 50.144 318.856 0 257 0z"></path></svg>
+}
+
+import ICON_SUCCESS from '../icon-success.png'
+import ICON_FAILURE from '../icon-failure.png'
+import ICON_PENDING from '../icon-pending.png'
+
+const conclusionIcon = (conclusion) => {
+  if      (conclusion === 'success') return ICON_SUCCESS
+  else if (conclusion === 'failure') return ICON_FAILURE
+  else                               return ICON_PENDING
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1088,25 +1088,6 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
-"@octokit/auth-token@^2.4.4":
-  version "2.4.5"
-  resolved "https://registry.yarnpkg.com/@octokit/auth-token/-/auth-token-2.4.5.tgz#568ccfb8cb46f36441fac094ce34f7a875b197f3"
-  integrity sha512-BpGYsPgJt05M7/L/5FoE1PiAbdxXFZkX/3kDYcsvd1v6UhlnE5e96dTDr0ezX/EFwciQxf3cNV0loipsURU+WA==
-  dependencies:
-    "@octokit/types" "^6.0.3"
-
-"@octokit/core@^3.2.3":
-  version "3.2.5"
-  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-3.2.5.tgz#57becbd5fd789b0592b915840855f3a5f233d554"
-  integrity sha512-+DCtPykGnvXKWWQI0E1XD+CCeWSBhB6kwItXqfFmNBlIlhczuDPbg+P6BtLnVBaRJDAjv+1mrUJuRsFSjktopg==
-  dependencies:
-    "@octokit/auth-token" "^2.4.4"
-    "@octokit/graphql" "^4.5.8"
-    "@octokit/request" "^5.4.12"
-    "@octokit/types" "^6.0.3"
-    before-after-hook "^2.1.0"
-    universal-user-agent "^6.0.0"
-
 "@octokit/endpoint@^6.0.1":
   version "6.0.11"
   resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-6.0.11.tgz#082adc2aebca6dcefa1fb383f5efb3ed081949d1"
@@ -1116,10 +1097,10 @@
     is-plain-object "^5.0.0"
     universal-user-agent "^6.0.0"
 
-"@octokit/graphql@^4.5.8":
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-4.6.0.tgz#f9abca55f82183964a33439d5264674c701c3327"
-  integrity sha512-CJ6n7izLFXLvPZaWzCQDjU/RP+vHiZmWdOunaCS87v+2jxMsW9FB5ktfIxybRBxZjxuJGRnxk7xJecWTVxFUYQ==
+"@octokit/graphql@^4.6.1":
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-4.6.1.tgz#f975486a46c94b7dbe58a0ca751935edc7e32cc9"
+  integrity sha512-2lYlvf4YTDgZCTXTW4+OX+9WTLFtEUc6hGm4qM1nlZjzxj+arizM4aHWzBVBCxY9glh7GIs0WEuiSgbVzv8cmA==
   dependencies:
     "@octokit/request" "^5.3.0"
     "@octokit/types" "^6.0.3"
@@ -1130,42 +1111,6 @@
   resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-4.0.1.tgz#bafd3d173974827ba0b733fcca7f1860cb71a9aa"
   integrity sha512-k2hRcfcLRyPJjtYfJLzg404n7HZ6sUpAWAR/uNI8tf96NgatWOpw1ocdF+WFfx/trO1ivBh7ckynO1rn+xAw/Q==
 
-"@octokit/plugin-paginate-rest@^2.6.2":
-  version "2.9.1"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.9.1.tgz#e9bb34a89b7ed5b801f1c976feeb9b0078ecd201"
-  integrity sha512-8wnuWGjwDIEobbBet2xAjZwgiMVTgIer5wBsnGXzV3lJ4yqphLU2FEMpkhSrDx7y+WkZDfZ+V+1cFMZ1mAaFag==
-  dependencies:
-    "@octokit/types" "^6.8.0"
-
-"@octokit/plugin-request-log@^1.0.2":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-request-log/-/plugin-request-log-1.0.3.tgz#70a62be213e1edc04bb8897ee48c311482f9700d"
-  integrity sha512-4RFU4li238jMJAzLgAwkBAw+4Loile5haQMQr+uhFq27BmyJXcXSKvoQKqh0agsZEiUlW6iSv3FAgvmGkur7OQ==
-
-"@octokit/plugin-rest-endpoint-methods@4.10.1":
-  version "4.10.1"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.10.1.tgz#b7a9181d1f52fef70a13945c5b49cffa51862da1"
-  integrity sha512-YGMiEidTORzgUmYZu0eH4q2k8kgQSHQMuBOBYiKxUYs/nXea4q/Ze6tDzjcRAPmHNJYXrENs1bEMlcdGKT+8ug==
-  dependencies:
-    "@octokit/types" "^6.8.2"
-    deprecation "^2.3.1"
-
-"@octokit/plugin-retry@^3.0.7":
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-retry/-/plugin-retry-3.0.7.tgz#174516f2b80b7140aee71ebc2b506db2c5c1d3d6"
-  integrity sha512-n08BPfVeKj5wnyH7IaOWnuKbx+e9rSJkhDHMJWXLPv61625uWjsN8G7sAW3zWm9n9vnS4friE7LL/XLcyGeG8Q==
-  dependencies:
-    "@octokit/types" "^6.0.3"
-    bottleneck "^2.15.3"
-
-"@octokit/plugin-throttling@^3.4.1":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-throttling/-/plugin-throttling-3.4.1.tgz#586aaa01ea653019380b137872c6256b0e2f2e5d"
-  integrity sha512-qCQ+Z4AnL9OrXvV59EH3GzPxsB+WyqufoCjiCJXJxTbnt3W+leXbXw5vHrMp4NG9ltw00McFWIxIxNQAzLNoTA==
-  dependencies:
-    "@octokit/types" "^6.0.1"
-    bottleneck "^2.15.3"
-
 "@octokit/request-error@^2.0.0":
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-2.0.5.tgz#72cc91edc870281ad583a42619256b380c600143"
@@ -1175,7 +1120,7 @@
     deprecation "^2.0.0"
     once "^1.4.0"
 
-"@octokit/request@^5.3.0", "@octokit/request@^5.4.12":
+"@octokit/request@^5.3.0":
   version "5.4.14"
   resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.4.14.tgz#ec5f96f78333bb2af390afa5ff66f114b063bc96"
   integrity sha512-VkmtacOIQp9daSnBmDI92xNIeLuSRDOIuplp/CJomkvzt7M18NXgG044Cx/LFKLgjKt9T2tZR6AtJayba9GTSA==
@@ -1189,17 +1134,7 @@
     once "^1.4.0"
     universal-user-agent "^6.0.0"
 
-"@octokit/rest@^18.0.15":
-  version "18.1.0"
-  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-18.1.0.tgz#9bf72604911a3433165bcc924263c9a706d32804"
-  integrity sha512-YQfpTzWV3jdzDPyXQVO54f5I2t1zxk/S53Vbe+Aa5vQj6MdTx6sNEWzmUzUO8lSVowbGOnjcQHzW1A8ATr+/7g==
-  dependencies:
-    "@octokit/core" "^3.2.3"
-    "@octokit/plugin-paginate-rest" "^2.6.2"
-    "@octokit/plugin-request-log" "^1.0.2"
-    "@octokit/plugin-rest-endpoint-methods" "4.10.1"
-
-"@octokit/types@^6.0.1", "@octokit/types@^6.0.3", "@octokit/types@^6.7.1", "@octokit/types@^6.8.0", "@octokit/types@^6.8.2":
+"@octokit/types@^6.0.3", "@octokit/types@^6.7.1":
   version "6.8.2"
   resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.8.2.tgz#ce4872e038d6df38b2d3c21bc12329af0b10facb"
   integrity sha512-RpG0NJd7OKSkWptiFhy1xCLkThs5YoDIKM21lEtDmUvSpbaIEfrxzckWLUGDFfF8RydSyngo44gDv8m2hHruUg==
@@ -1985,11 +1920,6 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-before-after-hook@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.1.1.tgz#99ae36992b5cfab4a83f6bee74ab27835f28f405"
-  integrity sha512-5ekuQOvO04MDj7kYZJaMab2S8SPjGJbotVNyv7QYFCOAwrGZs/YnoDNlh1U+m5hl7H2D/+n0taaAV/tfyd3KMA==
-
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -2065,11 +1995,6 @@ boolean@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/boolean/-/boolean-3.0.2.tgz#df1baa18b6a2b0e70840475e1d93ec8fe75b2570"
   integrity sha512-RwywHlpCRc3/Wh81MiCKun4ydaIFyW5Ea6JbL6sRCVx5q5irDw7pMXBUFYF/jArQ6YrG36q0kpovc9P/Kd3I4g==
-
-bottleneck@^2.15.3:
-  version "2.19.5"
-  resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.19.5.tgz#5df0b90f59fd47656ebe63c78a98419205cadd91"
-  integrity sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==
 
 boxen@^4.2.0:
   version "4.2.0"
@@ -3129,7 +3054,7 @@ depd@~1.1.2:
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
 
-deprecation@^2.0.0, deprecation@^2.3.1:
+deprecation@^2.0.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
   integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==


### PR DESCRIPTION
in the first place, thanks for building this lovely thingy :>

i tried to use it for my own repos, but there were no results. apparently github actions/workflows use a different thing from commit statuses, called checks *shrug*.

it seems the graphql api is the only api providing a combined status field for both of these (statusCheckRollup).

using graphql also saves a few requests. it allows querying the default ref directly, for instance.

the commit also adds a status icon to individual checks, so one can directly see which of the builds/test runs/checkers failed.

note: i have tested all combinations (repos with only classical status, repos with classical status and checks, repos with only checks, repos with nothing), but have tested NO throttling, retry, or network error cases.